### PR TITLE
Emit events when dragged

### DIFF
--- a/src/components/Polygon.ts
+++ b/src/components/Polygon.ts
@@ -49,7 +49,7 @@ export default class GmapsPolygon extends Vue {
   }
 
   private changedPath() {
-    if (this.polygon && this.polygon.getEditable()) {
+    if (this.polygon && (this.polygon.getEditable() || this.polygon.getDraggable())) {
       const result = this.polygon
         .getPath()
         .getArray()


### PR DESCRIPTION
It would be useful if the new path could be emitted if a polygon is draggable, but not editable. This PR just checks for either :smile: 